### PR TITLE
Adds HL7 datetime parsing capability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,22 @@
 PATH
   remote: .
   specs:
-    hl7 (1.0.0)
+    hl7 (1.0.1)
+      activesupport (>= 5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -20,6 +30,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/hl7.gemspec
+++ b/hl7.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", ">= 5.0"
+
   spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rspec", ">= 3.8"
 

--- a/lib/hl7.rb
+++ b/lib/hl7.rb
@@ -1,4 +1,5 @@
 require "hl7/message"
+require "hl7/datetime_parser"
 
 module HL7
   # This space intentionally left blank.

--- a/lib/hl7/datetime_components.rb
+++ b/lib/hl7/datetime_components.rb
@@ -1,0 +1,125 @@
+require 'active_support/core_ext/time'
+
+module HL7
+  class DatetimeComponents
+    attr_reader :year, :month, :day, :hour, :minute, :second, :fraction, :offset_seconds
+
+    def initialize(year, month = nil, day = nil, hour = nil, minute = nil, second = nil, fraction = nil, offset_seconds: nil)
+      @year = year
+      @month = month
+      @day = day
+      @hour = hour
+      @minute = minute
+      @second = second
+      @fraction = fraction
+      @offset_seconds = offset_seconds
+      validate!
+    end
+
+    def to_time(zone:)
+      full_seconds = second.to_i + fraction.to_f
+
+      if offset_seconds.nil?
+        Time.use_zone(zone) do
+          Time.zone.local(year, month, day, hour, minute, full_seconds)
+        end
+      else
+        Time.new(year, month, day, hour, minute, full_seconds, offset_seconds).
+          in_time_zone(zone)
+      end
+    end
+
+    def ==(other)
+      other.is_a?(DatetimeComponents) &&
+        self.to_time(zone: "UTC").eql?(other.to_time(zone: "UTC"))
+    end
+
+    private
+
+    def validate!
+      # year is not allowed to be nil
+      AttrSpec.new(:year, -9999..9999).validate_non_nil!(year)
+
+      # From month down to fraction-of-second, we validate the fields until we come
+      # to a nil value. Once we've found a nil, we ensure that all of the rest of
+      # the fields are also nil.
+      [
+        AttrSpec.new(:month, 1..12),
+        AttrSpec.new(:day, -> { 1..Time.days_in_month(month, year) }),
+        AttrSpec.new(:hour, 0..23),
+        AttrSpec.new(:minute, 0..59),
+        AttrSpec.new(:second, 0..59),
+        AttrSpec.new(:fraction, 0...1, :real?)
+      ].reduce(nil) do |first_nil_attr, spec|
+        value = public_send(spec.attr)
+        spec.validate!(value, first_nil_attr)
+      end
+
+      # offset_seconds is allowed to be nil or not
+      AttrSpec.new(:offset_seconds, -64800..64800).validate!(offset_seconds, nil)
+    end
+
+    class AttrSpec
+      attr_reader :attr
+
+      # The range_or_proc is either a Range or a callable that takes
+      # zero arguments and returns a Range. This allows Ranges to
+      # be lazily instantiated where necessary.
+      def initialize(attr, range_or_proc, predicate = :integer?)
+        @attr = attr
+        @range_or_proc = range_or_proc
+        @predicate = predicate
+      end
+
+      # This method always returns the first nil attribute that
+      # we've encountered, or nil if we haven't encountered one.
+      def validate!(value, first_nil_attr)
+        if first_nil_attr.nil?
+          # We haven't encountered a nil attribute yet, but this might
+          # be the first one.
+          if value.nil?
+            attr
+          else
+            validate_non_nil!(value)
+            nil
+          end
+        else
+          # We've already encountered a nil attribute, so
+          # this one is required to be nil.
+          ensure_nil!(value, first_nil_attr)
+          first_nil_attr
+        end
+      end
+
+      def validate_non_nil!(value)
+        unless value.respond_to?(predicate) && value.public_send(predicate)
+          raise ArgumentError, "#{attr} must satisfy #{predicate}; given #{value.inspect}"
+        end
+
+        unless range.cover?(value)
+          raise ArgumentError, "#{attr} must be within #{range}; given #{value.inspect}"
+        end
+      end
+
+      private
+
+      attr_reader :range_or_proc, :predicate
+
+      def range
+        if range_or_proc.respond_to?(:call)
+          range_or_proc.call
+        else
+          range_or_proc
+        end
+      end
+
+      def ensure_nil!(value, first_nil_attr)
+        unless value.nil?
+          raise ArgumentError, "#{attr} must be nil, because #{first_nil_attr} is nil; instead received #{value.inspect}"
+        end
+      end
+    end
+
+    private_constant :AttrSpec
+  end
+end

--- a/lib/hl7/datetime_parser.rb
+++ b/lib/hl7/datetime_parser.rb
@@ -1,0 +1,71 @@
+require "hl7/datetime_components"
+require "active_support/core_ext/module/delegation"
+
+module HL7
+  class DatetimeParser
+    # The HL7 datetime format is:
+    #    YYYY[MM[DD[HH[MM[SS[.S[S[S[S]]]]]]]]][+/-ZZZZ]
+    RX = /\A(\d{4})(?:(\d{2})(?:(\d{2})(?:(\d{2})(?:(\d{2})(?:(\d{2})(\.\d{1,4})?)?)?)?)?)?([-+]\d{4})?\Z/.freeze
+
+    def initialize(text)
+      @text = text
+    end
+
+    def components
+      @components ||= (
+        # year cannot be nil
+        year, month, day, hour, minute, second, fraction, offset = match
+
+        DatetimeComponents.new(
+          year.to_i,
+          month&.to_i,
+          day&.to_i,
+          hour&.to_i,
+          minute&.to_i,
+          second&.to_i,
+          fraction&.to_f,
+          offset_seconds: offset_seconds(offset)
+        )
+      )
+    end
+
+    delegate :to_time, to: :components
+
+    private
+
+    attr_reader :text
+
+    def match
+      match_data = text.match(RX)
+
+      if match_data.nil?
+        raise ArgumentError, "Invalid HL7 datetime: #{text.inspect}"
+      end
+
+      # When we convert MatchData to an Array, the zeroth
+      # element is the entire matched string. We only want the
+      # matched groups, so we drop the zeroth element.
+      match_data.to_a.drop(1)
+    end
+
+    # argument is a string that looks like:
+    #   -0500
+    def offset_seconds(str)
+      if str.nil?
+        nil
+      else
+        sign = str[0]
+        hours = str[1..2].to_i
+        minutes = str[3..4].to_i
+
+        abs = (hours * 3600) + (minutes * 60)
+
+        if sign == "-"
+          -abs
+        else
+          abs
+        end
+      end
+    end
+  end
+end

--- a/lib/hl7/version.rb
+++ b/lib/hl7/version.rb
@@ -1,3 +1,3 @@
 module HL7
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end

--- a/spec/hl7/datetime_components_spec.rb
+++ b/spec/hl7/datetime_components_spec.rb
@@ -1,0 +1,133 @@
+RSpec.describe HL7::DatetimeComponents do
+  describe "[validation]" do
+    it "requires the year to be an integer in [-9999, 9999]" do
+      expect { HL7::DatetimeComponents.new(2019.5) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(-10000) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(10000) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019) }.
+        not_to raise_error
+    end
+
+    it "requires the month to be an integer in [1, 12]" do
+      expect { HL7::DatetimeComponents.new(2019, -2) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 20) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2) }.
+        not_to raise_error
+    end
+
+    it "requires the day-of-month to exist, given the year and month" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 12.5) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 0) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 29) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28) }.
+        not_to raise_error
+
+      expect { HL7::DatetimeComponents.new(2000, 2, 29) }.
+        not_to raise_error
+    end
+
+    it "requires the hour to be an integer in [0, 23]" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0.001) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, -1) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 24) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0) }.
+        not_to raise_error
+    end
+
+    it "requires the minute to be an integer in [0, 59]" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, "hi") }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 12, -1) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 12, 100) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 30) }.
+        not_to raise_error
+    end
+
+    it "requires the second to be an integer in [0, 59]" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, "blah") }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 12, 50, -30) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 12, 50, 60) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23) }.
+        not_to raise_error
+    end
+
+    it "requires the fraction to be a real in [0, 1)" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, -1) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, 1) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, 0.45) }.
+        not_to raise_error
+    end
+
+    it "requires the offset_seconds to be an integer in [-64800, 64800]" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, 0.45, offset_seconds: -100000) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, 0.45, offset_seconds: 100000) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, 0, 50, 23, 0.45, offset_seconds: 18000) }.
+        not_to raise_error
+    end
+
+    it "requires that if any component is nil, all less-significant components are also nil" do
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, nil, 10) }.
+        to raise_error(ArgumentError)
+
+      expect { HL7::DatetimeComponents.new(2019, 2, 28, nil, nil) }.
+        not_to raise_error
+    end
+  end
+
+  describe "#to_time" do
+    it "is the correct Time instance" do
+      expect(
+        HL7::DatetimeComponents.
+          new(1990, 2, 20, 15, 20, 54, 0.23, offset_seconds: -18000).
+          to_time(zone: "UTC")
+      ).to eq(Time.utc(1990, 2, 20, 20, 20, 54.23))
+
+      expect(
+        HL7::DatetimeComponents.
+          new(1990, 2, 20).
+          to_time(zone: "UTC")
+      ).to eq(Time.utc(1990, 2, 20))
+    end
+  end
+end

--- a/spec/hl7/datetime_parser_spec.rb
+++ b/spec/hl7/datetime_parser_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe HL7::DatetimeParser do
+  describe "#components" do
+    it "is HL7::DatetimeComponents parsed from the given string" do
+      expect( HL7::DatetimeParser.new("20190326").components).to eq(
+        HL7::DatetimeComponents.new(2019, 3, 26)
+      )
+
+      expect( HL7::DatetimeParser.new("20190326140953").components).to eq(
+        HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53)
+      )
+
+      expect( HL7::DatetimeParser.new("20190326140953.425").components).to eq(
+        HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53, 0.425)
+      )
+
+      expect( HL7::DatetimeParser.new("20190326140953.425-0500").components).to eq(
+        HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53, 0.425, offset_seconds: -18000)
+      )
+    end
+
+    it "raises ArgumentError when the given text cannot be parsed" do
+      expect { HL7::DatetimeParser.new("hello").components }.
+        to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
This is based on `Mirth::DateTimeParser` in connect, with a few changes.
Also, it adds a dependency on `activesupport`, for its time zone handling code.