### PR TITLE
Use underscore convention for instance vars used for memoizing

### DIFF
--- a/lib/hl7/component.rb
+++ b/lib/hl7/component.rb
@@ -12,7 +12,7 @@ module HL7
     end
 
     def subcomponents
-      @subcomponents ||= text.split(delimiters.subcomponent).map do |sub_text|
+      @_subcomponents ||= text.split(delimiters.subcomponent).map do |sub_text|
         Subcomponent.new(sub_text.freeze, delimiters)
       end
     end

--- a/lib/hl7/datetime_parser.rb
+++ b/lib/hl7/datetime_parser.rb
@@ -12,7 +12,7 @@ module HL7
     end
 
     def components
-      @components ||= (
+      @_components ||= (
         # year cannot be nil
         year, month, day, hour, minute, second, fraction, offset = match
 

--- a/lib/hl7/delimiters.rb
+++ b/lib/hl7/delimiters.rb
@@ -72,14 +72,14 @@ module HL7
     private
 
     def unescape_regexp
-      @unescape_regexp ||= (
+      @_unescape_regexp ||= (
         e = Regexp.quote(escape)
         /#{e}F#{e}|#{e}S#{e}|#{e}T#{e}|#{e}R#{e}|#{e}E#{e}/
       )
     end
 
     def unescape_replacements
-      @unescape_replacements ||= (
+      @_unescape_replacements ||= (
         e = escape
 
         {
@@ -93,7 +93,7 @@ module HL7
     end
 
     def escape_regexp
-      @escape_regexp ||= [field, component, subcomponent, repeat, escape].
+      @_escape_regexp ||= [field, component, subcomponent, repeat, escape].
         compact.
         map(&Regexp.method(:quote)).
         join("|").
@@ -101,7 +101,7 @@ module HL7
     end
 
     def escape_replacements
-      @escape_replacements ||= (
+      @_escape_replacements ||= (
         e = escape
 
         {

--- a/lib/hl7/delimiters_parser.rb
+++ b/lib/hl7/delimiters_parser.rb
@@ -43,7 +43,7 @@ module HL7
     # occurrence. That marks the end of MSH.2. If we don't find one, just
     # use the end of the text.
     def end_of_delimiters
-      @end_of_delimiters ||=
+      @_end_of_delimiters ||=
         @text.index(field_delimiter, FIELD_DELIM_IDX + 1) || @text.length
     end
 

--- a/lib/hl7/field.rb
+++ b/lib/hl7/field.rb
@@ -12,7 +12,7 @@ module HL7
     end
 
     def repetitions
-      @repetitions ||= text.split(delimiters.repeat).map do |rep_text|
+      @_repetitions ||= text.split(delimiters.repeat).map do |rep_text|
         Repetition.new(rep_text.freeze, delimiters)
       end
     end

--- a/lib/hl7/msh_segment.rb
+++ b/lib/hl7/msh_segment.rb
@@ -6,7 +6,7 @@ module HL7
     # The MSH segment counts fields a bit differently, since it contains
     # the delimiters.
     def fields
-      @fields ||= (
+      @_fields ||= (
         later_fields = text[4..-1].split(delimiters.field)
         all_fields = [name, delimiters.field] + later_fields
 

--- a/lib/hl7/repetition.rb
+++ b/lib/hl7/repetition.rb
@@ -12,7 +12,7 @@ module HL7
     end
 
     def components
-      @components ||= text.split(delimiters.component).map do |comp_text|
+      @_components ||= text.split(delimiters.component).map do |comp_text|
         Component.new(comp_text.freeze, delimiters)
       end
     end

--- a/lib/hl7/segment.rb
+++ b/lib/hl7/segment.rb
@@ -15,7 +15,7 @@ module HL7
     end
 
     def fields
-      @fields ||= text.split(delimiters.field).map do |field_text|
+      @_fields ||= text.split(delimiters.field).map do |field_text|
         Field.new(field_text.freeze, delimiters)
       end
     end

--- a/lib/hl7/version.rb
+++ b/lib/hl7/version.rb
@@ -1,3 +1,3 @@
 module HL7
-  VERSION = "1.1.0".freeze
+  VERSION = "1.1.1".freeze
 end


### PR DESCRIPTION
Based on @hernanat's comments in my last PR.