### PR TITLE
Do not perform HL7 escaping on Mirth XML text

### DIFF
--- a/lib/hl7/mirth_xml_parser.rb
+++ b/lib/hl7/mirth_xml_parser.rb
@@ -96,7 +96,7 @@ module HL7
       components = field.element_children
 
       if components.empty?
-        delimiters.escape_text(field.content)
+        field.content
       else
         components.
           map { |component| parse_component(component, delimiters) }.
@@ -108,10 +108,10 @@ module HL7
       subcomponents = component.element_children
 
       if subcomponents.empty? || delimiters.subcomponent.nil?
-        delimiters.escape_text(component.content)
+        component.content
       else
         subcomponents.
-          map { |subcomponent| delimiters.escape_text(subcomponent.content) }.
+          map(&:content).
           join(delimiters.subcomponent)
       end
     end

--- a/spec/hl7/mirth_xml_parser_spec.rb
+++ b/spec/hl7/mirth_xml_parser_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe HL7::MirthXmlParser do
 
       expect { parser.to_hl7 }.to raise_error(HL7::FormatError)
     end
+
+    it "passes through HL7 escapes" do
+      parser = HL7::MirthXmlParser.new(xml_with_hl7_escapes)
+      hl7 = parser.to_hl7
+      expect(hl7).to eq("MSH|^~\\&|Foo\\F\\Bar\r")
+    end
   end
 
   def pcc_a01_xml
@@ -48,6 +54,20 @@ RSpec.describe HL7::MirthXmlParser do
         <MSH>
           <MSH.1>X</MSH.1>
           <MSH.2>Y</MSH.2>
+        </MSH>
+      </HL7Message>
+    XML
+  end
+
+  def xml_with_hl7_escapes
+    <<~XML
+      <HL7Message>
+        <MSH>
+          <MSH.1>|</MSH.1>
+          <MSH.2>^~\\&amp;</MSH.2>
+          <MSH.3>
+              <MSH.3.1>Foo\\F\\Bar</MSH.3.1>
+          </MSH.3>
         </MSH>
       </HL7Message>
     XML


### PR DESCRIPTION
Mirth doesn't unescape HL7 before putting it into XML elements,
so we don't want to escape it here, otherwise, it will be
double-escaped.