### PR TITLE
Validates UTC offset in an HL7 datetime

### DIFF
--- a/lib/hl7/version.rb
+++ b/lib/hl7/version.rb
@@ -1,3 +1,3 @@
 module HL7
-  VERSION = "1.1.1".freeze
+  VERSION = "1.1.2".freeze
 end

--- a/spec/hl7/datetime_parser_spec.rb
+++ b/spec/hl7/datetime_parser_spec.rb
@@ -1,25 +1,30 @@
 RSpec.describe HL7::DatetimeParser do
   describe "#components" do
     it "is HL7::DatetimeComponents parsed from the given string" do
-      expect( HL7::DatetimeParser.new("20190326").components).to eq(
+      expect(HL7::DatetimeParser.new("20190326").components).to eq(
         HL7::DatetimeComponents.new(2019, 3, 26)
       )
 
-      expect( HL7::DatetimeParser.new("20190326140953").components).to eq(
+      expect(HL7::DatetimeParser.new("20190326140953").components).to eq(
         HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53)
       )
 
-      expect( HL7::DatetimeParser.new("20190326140953.425").components).to eq(
+      expect(HL7::DatetimeParser.new("20190326140953.425").components).to eq(
         HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53, 0.425)
       )
 
-      expect( HL7::DatetimeParser.new("20190326140953.425-0500").components).to eq(
+      expect(HL7::DatetimeParser.new("20190326140953.425-0500").components).to eq(
         HL7::DatetimeComponents.new(2019, 3, 26, 14, 9, 53, 0.425, offset_seconds: -18000)
       )
     end
 
     it "raises ArgumentError when the given text cannot be parsed" do
       expect { HL7::DatetimeParser.new("hello").components }.
+        to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError when given an illegal UTC offset" do
+      expect { HL7::DatetimeParser.new("20190326140953.425-0070").components }.
         to raise_error(ArgumentError)
     end
   end


### PR DESCRIPTION
Previously, values like "-0070" would have been accepted and
interpreted as 70 minutes behind UTC. That isn't correct, though.
(If that were the intention, it ought to be "-01:10"). It's far
more likely a mistake that ought to be caught.