### PR TITLE
Adds precision method to DatetimeComponents

### DIFF
--- a/lib/hl7/datetime_parser.rb
+++ b/lib/hl7/datetime_parser.rb
@@ -75,7 +75,7 @@ module HL7
       )
     end
 
-    delegate :to_time, to: :components
+    delegate :to_time, :precision, to: :components
 
     private
 

--- a/spec/hl7/datetime_components_spec.rb
+++ b/spec/hl7/datetime_components_spec.rb
@@ -130,4 +130,16 @@ RSpec.describe HL7::DatetimeComponents do
       ).to eq(Time.utc(1990, 2, 20))
     end
   end
+
+  describe "#precision" do
+    it "is the name of the least-significant non-nil component (not counting UTC offset)" do
+      expect(HL7::DatetimeComponents.new(1990).precision).to eq(:year)
+      expect(HL7::DatetimeComponents.new(1990, 2).precision).to eq(:month)
+      expect(HL7::DatetimeComponents.new(1990, 2, 20).precision).to eq(:day)
+      expect(HL7::DatetimeComponents.new(1990, 2, 20, 15).precision).to eq(:hour)
+      expect(HL7::DatetimeComponents.new(1990, 2, 20, 15, 20).precision).to eq(:minute)
+      expect(HL7::DatetimeComponents.new(1990, 2, 20, 15, 20, 54).precision).to eq(:second)
+      expect(HL7::DatetimeComponents.new(1990, 2, 20, 15, 20, 54, 0.23).precision).to eq(:fraction)
+    end
+  end
 end

--- a/spec/hl7/datetime_parser_spec.rb
+++ b/spec/hl7/datetime_parser_spec.rb
@@ -28,4 +28,21 @@ RSpec.describe HL7::DatetimeParser do
         to raise_error(ArgumentError)
     end
   end
+
+  describe "#precision" do
+    it "should be correct, based on the provided fields in the input string" do
+      expect(HL7::DatetimeParser.new("2019").precision).to eq(:year)
+      expect(HL7::DatetimeParser.new("201903").precision).to eq(:month)
+      expect(HL7::DatetimeParser.new("20190326").precision).to eq(:day)
+      expect(HL7::DatetimeParser.new("2019032612").precision).to eq(:hour)
+      expect(HL7::DatetimeParser.new("201903261230").precision).to eq(:minute)
+      expect(HL7::DatetimeParser.new("20190326123022").precision).to eq(:second)
+      expect(HL7::DatetimeParser.new("20190326123022.07").precision).to eq(:fraction)
+    end
+
+    it "should raise ArgumentError when the given text cannot be parsed" do
+      expect { HL7::DatetimeParser.new("hello").precision }.
+        to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
An HL7 DTM value specifies its precision by its length. For example,
while "1990" and "19900101" might be parsed as the same timestamp,
the former indicates that it is precise to the year, while the
second indicates that it is precise to the month. This is a
meaningful distinction that is lost by simply producing date/time
values from the two strings.

This PR adds a method, DatetimeComponents#precision, which
returns the name of the least significant component that is
present in the input. The possible return values are:

year
month
day
hour
minute
second
fraction

Note that nil is not a possible return value, since all DTM values
must provide at least a year to be valid. Trying to create a
DatetimeComponent value from an invalid DTM string raises an
exception.