### PR TITLE
add active_support import

### DIFF
--- a/lib/hl7/datetime_components.rb
+++ b/lib/hl7/datetime_components.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/time'
 
 module HL7

--- a/lib/hl7/version.rb
+++ b/lib/hl7/version.rb
@@ -1,3 +1,3 @@
 module HL7
-  VERSION = "1.1.2".freeze
+  VERSION = "1.1.3".freeze
 end


### PR DESCRIPTION
While exploring this gem, I discovered that two specs were erroring with `uninitialized constant ActiveSupport::IsolatedExecutionState` with ActiveSupport 7.0.4.3, and Ruby 3.2.1 

Further investigation showed that requiring ActiveSupport in `datetime_components.rb` would resolve this issue. 

The version has also been bumped from 1.1.2 to 1.1.3.